### PR TITLE
fix: correct coalesce functions for location and resource_group_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@
 resource "azurerm_private_endpoint" "endpoint" {
   for_each = {
     for k, v in var.endpoints : k => merge(v, {
-      location             = var.location
+      location             = try(v.location, var.location)
+      resource_group_name  = try(v.resource_group, var.resource_group)
       private_dns_zone_ids = try(v.private_dns_zone_ids, [])
       tags                 = try(v.tags, var.tags, {})
       ip_configurations    = try(v.ip_configurations, {})
@@ -10,8 +11,8 @@ resource "azurerm_private_endpoint" "endpoint" {
   }
 
   name                          = each.value.name
-  resource_group_name           = coalesce(lookup(var.endpoints, "resource_group", null), var.resource_group)
-  location                      = coalesce(lookup(var.endpoints, "location", null), var.location)
+  resource_group_name           = each.value.resource_group_name
+  location                      = each.value.location
   subnet_id                     = each.value.subnet_id
   custom_network_interface_name = try(each.value.custom_network_interface_name, null)
   tags                          = each.value.tags


### PR DESCRIPTION
## Description

Bug fix: Issue in coalesce functions for location and resource_group_name

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
