### PR TITLE
fix: Make private_connection_resource_id optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_private_endpoint" "endpoint" {
   private_service_connection {
     name                              = each.key
     is_manual_connection              = try(each.value.is_manual_connection, false)
-    private_connection_resource_id    = each.value.private_connection_resource_id
+    private_connection_resource_id    = try(each.value.private_connection_resource_id, null)
     subresource_names                 = each.value.subresource_names
     private_connection_resource_alias = try(each.value.private_connection_resource_alias, null)
     request_message                   = try(each.value.request_message, null)


### PR DESCRIPTION
## Description

The private_connection_resource_id is an optional value. According to the documentation:
_One of private_connection_resource_id or private_connection_resource_alias must be specified_

This change will make the private_connection_resource_id optional.

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Make the private_connection_resource_id optional.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
